### PR TITLE
fix: pg tweaks

### DIFF
--- a/pg-wasm/board/pg-wasm/post-image.sh
+++ b/pg-wasm/board/pg-wasm/post-image.sh
@@ -6,6 +6,7 @@ tar -xf rootfs.tar -C rootfs
 mv bzImage rootfs
 # rm -rf filesystem*
 find rootfs -type f -iname '\.gitkeep' -delete
+rm rootfs/etc/init.d/S50postgresql
 chown -R 1000:1000 rootfs
 chown -R 100:101 rootfs/var/lib/pgsql
 chmod 700 rootfs/var/lib/pgsql

--- a/pg-wasm/board/pg-wasm/rootfs_overlay/var/lib/pgsql/postgresql.conf
+++ b/pg-wasm/board/pg-wasm/rootfs_overlay/var/lib/pgsql/postgresql.conf
@@ -124,7 +124,7 @@ max_connections = 100			# (change requires restart)
 
 # - Memory -
 
-shared_buffers = 128MB			# min 128kB
+shared_buffers = 64MB			# min 128kB
 					# (change requires restart)
 #huge_pages = try			# on, off, or try
 					# (change requires restart)


### PR DESCRIPTION
- Delete the S50postgresql to avoid having pg started on boot
- shared_buffers = 64MB instead of 128MB to be able to use 128MB of ram disk with v86